### PR TITLE
Add `lower_camel` modifier for lower-camel case identifiers

### DIFF
--- a/src/segment.rs
+++ b/src/segment.rs
@@ -225,7 +225,7 @@ pub(crate) fn paste(segments: &[Segment]) -> Result<String> {
                             if ch != '_' {
                                 match prev {
                                     Previous::First => acc.push(ch),
-                                    Previous::Letter(prev) if prev == '_' => {
+                                    Previous::Letter('_') => {
                                         for chu in ch.to_uppercase() {
                                             acc.push(chu);
                                         }

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -213,6 +213,35 @@ pub(crate) fn paste(segments: &[Segment]) -> Result<String> {
                         }
                         evaluated.push(acc);
                     }
+                    "lower_camel" => {
+                        enum Previous {
+                            First,
+                            Letter(char),
+                        }
+
+                        let mut acc = String::new();
+                        let mut prev = Previous::First;
+                        for ch in last.chars() {
+                            if ch != '_' {
+                                match prev {
+                                    Previous::First => acc.push(ch),
+                                    Previous::Letter(prev) if prev == '_' => {
+                                        for chu in ch.to_uppercase() {
+                                            acc.push(chu);
+                                        }
+                                    }
+                                    Previous::Letter(prev) if prev.is_uppercase() => {
+                                        for chl in ch.to_lowercase() {
+                                            acc.push(chl);
+                                        }
+                                    }
+                                    Previous::Letter(_) => acc.push(ch),
+                                }
+                            }
+                            prev = Previous::Letter(ch);
+                        }
+                        evaluated.push(acc);
+                    }
                     _ => {
                         return Err(Error::new2(
                             colon.span,

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -163,6 +163,29 @@ mod test_to_camel {
     }
 }
 
+mod test_to_lower_camel {
+    use paste2::paste;
+
+    macro_rules! m {
+        ($id:ident) => {
+            paste! {
+                const DEFAULT_CAMEL: &str = stringify!([<$id:lower_camel>]);
+                const LOWER_CAMEL: &str = stringify!([<$id:lower_camel:lower>]);
+                const UPPER_CAMEL: &str = stringify!([<$id:lower_camel:upper>]);
+            }
+        };
+    }
+
+    m!(this_is_but_a_test);
+
+    #[test]
+    fn test_to_camel() {
+        assert_eq!(DEFAULT_CAMEL, "thisIsButATest");
+        assert_eq!(LOWER_CAMEL, "thisisbutatest");
+        assert_eq!(UPPER_CAMEL, "THISISBUTATEST");
+    }
+}
+
 mod test_doc_expr {
     // https://github.com/dtolnay/paste/issues/29
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new "lower_camel" case transformation modifier for identifier formatting.

- **Tests**
  - Added tests to verify correct behavior of the new "lower_camel" case transformation, including default, lower, and upper casing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->